### PR TITLE
Implement basic validation of CU-request bodies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-json": "*",
+        "doctrine/annotations": "^1.8",
         "sensio/framework-extra-bundle": "^5.5",
         "symfony/console": "5.0.1",
         "symfony/dotenv": "5.0.1",
@@ -16,6 +17,7 @@
         "symfony/property-info": "5.0.1",
         "symfony/serializer": "5.0.1",
         "symfony/translation": "5.0.1",
+        "symfony/validator": "5.0.1",
         "symfony/yaml": "5.0.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffb7b9f6bd8daa47c27ae9c221812d9b",
+    "content-hash": "aa4a7836866d0ae2e94e46d8040d41f2",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -3620,6 +3620,98 @@
                 "standards"
             ],
             "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "symfony/validator",
+            "version": "v5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "09af8612c2724960b4a604b65ddfe0ec352091b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/09af8612c2724960b4a604b65ddfe0ec352091b6",
+                "reference": "09af8612c2724960b4a604b65ddfe0ec352091b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "doctrine/lexer": "<1.0.2",
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/http-kernel": "<4.4",
+                "symfony/intl": "<4.4",
+                "symfony/translation": "<4.4",
+                "symfony/yaml": "<4.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.7",
+                "doctrine/cache": "~1.0",
+                "egulias/email-validator": "^2.1.10",
+                "symfony/cache": "^4.4|^5.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/intl": "^4.4|^5.0",
+                "symfony/property-access": "^4.4|^5.0",
+                "symfony/property-info": "^4.4|^5.0",
+                "symfony/translation": "^4.4|^5.0",
+                "symfony/yaml": "^4.4|^5.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
+                "doctrine/cache": "For using the default cached annotation reader.",
+                "egulias/email-validator": "Strict (RFC compliant) email validation",
+                "psr/cache-implementation": "For using the mapping cache.",
+                "symfony/config": "",
+                "symfony/expression-language": "For using the Expression validator",
+                "symfony/http-foundation": "",
+                "symfony/intl": "",
+                "symfony/property-access": "For accessing properties within comparison constraints",
+                "symfony/property-info": "To automatically add NotNull and Type constraints",
+                "symfony/translation": "For translating validation errors.",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Validator\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Validator Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-11-30T14:12:50+00:00"
         },
         {
             "name": "symfony/var-dumper",

--- a/config/packages/test/validator.yaml
+++ b/config/packages/test/validator.yaml
@@ -1,0 +1,3 @@
+framework:
+    validation:
+        not_compromised_password: false

--- a/config/packages/validator.yaml
+++ b/config/packages/validator.yaml
@@ -1,0 +1,3 @@
+framework:
+    validation:
+        email_validation_mode: html5

--- a/src/Controller/v1/RecipeController.php
+++ b/src/Controller/v1/RecipeController.php
@@ -8,6 +8,7 @@ use App\Service\RecipeService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @Route(path="/v1/recipe")
@@ -16,9 +17,14 @@ class RecipeController extends AbstractController
 {
     private RecipeService $recipeService;
 
-    public function __construct(RecipeService $recipeService)
-    {
+    private ValidatorInterface $validator;
+
+    public function __construct(
+        RecipeService $recipeService,
+        ValidatorInterface $validator
+    ) {
         $this->recipeService = $recipeService;
+        $this->validator = $validator;
     }
 
     /**
@@ -30,6 +36,12 @@ class RecipeController extends AbstractController
      */
     public function createRecipe(Recipe $fromBody): JsonResponse
     {
+        $errors = $this->validator->validate($fromBody);
+
+        if (count($errors) > 0) {
+            return $this->json(['errors' => (string)$errors], 400);
+        }
+
         $recipe = $this->recipeService->addOrUpdate($fromBody);
 
         return $this->json($recipe, 201);
@@ -75,6 +87,12 @@ class RecipeController extends AbstractController
      */
     public function updateRecipe(Recipe $fromBody, int $id): JsonResponse
     {
+        $errors = $this->validator->validate($fromBody);
+
+        if (count($errors) > 0) {
+            return $this->json(['errors' => (string)$errors]);
+        }
+
         $oldRecipe = $this->recipeService->getById($id);
 
         if ($oldRecipe === null) {

--- a/src/Controller/v1/RecipeController.php
+++ b/src/Controller/v1/RecipeController.php
@@ -4,9 +4,11 @@ declare(strict_types = 1);
 namespace App\Controller\v1;
 
 use App\Entity\Recipe;
+use App\Helpers\Traits\ValidationErrorsTrait;
 use App\Service\RecipeService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -15,6 +17,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  */
 class RecipeController extends AbstractController
 {
+    use ValidationErrorsTrait;
+
     private RecipeService $recipeService;
 
     private ValidatorInterface $validator;
@@ -39,12 +43,12 @@ class RecipeController extends AbstractController
         $errors = $this->validator->validate($fromBody);
 
         if (count($errors) > 0) {
-            return $this->json(['errors' => (string)$errors], 400);
+            return $this->createValidationErrorResponse($errors);
         }
 
         $recipe = $this->recipeService->addOrUpdate($fromBody);
 
-        return $this->json($recipe, 201);
+        return $this->json($recipe, Response::HTTP_CREATED);
     }
 
     /**
@@ -90,7 +94,7 @@ class RecipeController extends AbstractController
         $errors = $this->validator->validate($fromBody);
 
         if (count($errors) > 0) {
-            return $this->json(['errors' => (string)$errors]);
+            return $this->createValidationErrorResponse($errors);
         }
 
         $oldRecipe = $this->recipeService->getById($id);

--- a/src/Entity/Recipe.php
+++ b/src/Entity/Recipe.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use DateTime;
 use DateTimeInterface;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity(repositoryClass="App\Repository\RecipeRepository")
@@ -20,13 +21,18 @@ class Recipe
 
     /**
      * @ORM\Column(type="string", length=255)
+     *
+     * @Assert\NotBlank()
      */
-    private ?string $name;
+    private string $name = '';
 
     /**
      * @ORM\Column(type="string", length=255)
+     *
+     * @Assert\NotBlank()
+     * @Assert\Email()
      */
-    private ?string $author;
+    private string $author = '';
 
     /**
      * @ORM\Column(type="datetime")
@@ -49,7 +55,7 @@ class Recipe
         return $this->id;
     }
 
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
@@ -61,7 +67,7 @@ class Recipe
         return $this;
     }
 
-    public function getAuthor(): ?string
+    public function getAuthor(): string
     {
         return $this->author;
     }

--- a/src/Helpers/Traits/ValidationErrorsTrait.php
+++ b/src/Helpers/Traits/ValidationErrorsTrait.php
@@ -5,12 +5,23 @@ namespace App\Helpers\Traits;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
+use function array_map;
+use function iterator_to_array;
 
 trait ValidationErrorsTrait
 {
     protected function createValidationErrorResponse(ConstraintViolationListInterface $validationErrors): JsonResponse
     {
-        return new JsonResponse(['errors' => (string)$validationErrors], Response::HTTP_BAD_REQUEST);
+        $errors = array_map(
+            fn(ConstraintViolationInterface $violation) => [
+                'property' => $violation->getPropertyPath(),
+                'message' => $violation->getMessage()
+            ],
+            iterator_to_array($validationErrors)
+        );
+
+        return new JsonResponse(['errors' => $errors], Response::HTTP_BAD_REQUEST);
     }
 }

--- a/src/Helpers/Traits/ValidationErrorsTrait.php
+++ b/src/Helpers/Traits/ValidationErrorsTrait.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types = 1);
+
+namespace App\Helpers\Traits;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+trait ValidationErrorsTrait
+{
+    protected function createValidationErrorResponse(ConstraintViolationListInterface $validationErrors): JsonResponse
+    {
+        return new JsonResponse(['errors' => (string)$validationErrors], Response::HTTP_BAD_REQUEST);
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -297,6 +297,19 @@
     "symfony/translation-contracts": {
         "version": "v2.0.0"
     },
+    "symfony/validator": {
+        "version": "4.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.3",
+            "ref": "d902da3e4952f18d3bf05aab29512eb61cabd869"
+        },
+        "files": [
+            "config/packages/test/validator.yaml",
+            "config/packages/validator.yaml"
+        ]
+    },
     "symfony/var-dumper": {
         "version": "v5.0.0"
     },


### PR DESCRIPTION
Add simple validation to the POST / PUT request bodies. Use the `symfony/validator` to check object properties and their validity.

Closes #32 